### PR TITLE
Playground executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,55 @@
 language: julia
-sudo: false
 os:
-  - osx
-  - linux
+- osx
+- linux
 julia:
-  #- release
-  #- nightly
-  - 0.4
+- 0.4
+env:
+  global:
+    secure: CD5Wv1UQ8oM+3tLPBxWiWS9XdMfFxwCSKbMzteaFrtSgY06DIdNON6cPr3zKARHHKiX0hsznU3vNTnOkYfXrmEPocep5YDBNccA3uWTUfP/j/Zrg2oUuTdc2ZKhUZIupqQf6FfJ8IudgrMrWd/LRBchKahNSCmvomP+4cXRTouk=
 notifications:
   email: false
+before_install:
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    sudo add-apt-repository ppa:staticfloat/julia-deps -y;
+    sudo apt-get update -qq -y;
+    sudo apt-get install patchelf;
+  fi
 script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --depwarn=no -e 'Pkg.init(); Pkg.clone(pwd()); ENV["PLAYGROUND_INSTALL"] = true; Pkg.build("Playground"); Pkg.test("Playground";  coverage=true)'
-  #- ~/.playground/bin/playground list
-after_success:
-  - julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-  - julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+- if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+# initial clone so that we install the dependencies correctly, but this copies the pwd
+- julia -e 'Pkg.clone(pwd())'
+- ls "$PWD"
+- ls "$HOME/.julia/v$TRAVIS_JULIA_VERSION"
+# remove the copy
+- rm -rf "$HOME/.julia/v$TRAVIS_JULIA_VERSION/Playground"
+# symlink in the pwd
+- ln -s "$PWD" "$HOME/.julia/v$TRAVIS_JULIA_VERSION/Playground"
+# now build playground
+- julia --depwarn=no -e 'ENV["PLAYGROUND_INSTALL"] = true; Pkg.build("Playground")'
+#  Pkg.test("Playground";  coverage=true)'
+- ~/.playground/bin/playground list
+#after_success:
+#- julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+#- julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+before_deploy:
+# Assuming skip_cleanup works the README.md and the build directory we want should be under the pwd
+- echo "Attempting to bundle playground..."
+- ls "$PWD"
+- ls "$PWD/deps/usr/build"
+- cp ./README.md ./deps/usr/build/README.md
+- cp ./LICENSE ./deps/usr/build/LICENSE
+- tar -czvf "playground-$TRAVIS_OS_NAME.tar.gz" ./deps/usr/build
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 --binary "playground-osx.tar.gz" > "SHA256SUM-osx.asc"; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum --binary "playground-linux.tar.gz" > "SHA256SUM-linux.asc"; fi
+deploy:
+  provider: releases
+  api_key: ${GITHUB_TOKEN}
+  file:
+  - "playground-$TRAVIS_OS_NAME.tar.gz"
+  - "SHA256SUM-$TRAVIS_OS_NAME.asc"
+  skip_cleanup: true
+  on:
+    tags: true
+    all_branches: true
+    repo: Rory-Finnegan/Playground.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,20 +26,20 @@ script:
 # symlink in the pwd
 - ln -s "$PWD" "$HOME/.julia/v$TRAVIS_JULIA_VERSION/Playground"
 # now build playground
-- julia --depwarn=no -e 'ENV["PLAYGROUND_INSTALL"] = true; Pkg.build("Playground")'
-#  Pkg.test("Playground";  coverage=true)'
+- julia --depwarn=no -e 'ENV["PLAYGROUND_INSTALL"] = true; Pkg.build("Playground");
+  Pkg.test("Playground";  coverage=true)'
 - ~/.playground/bin/playground list
-#after_success:
-#- julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-#- julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+after_success:
+- julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+- julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
 before_deploy:
 # Assuming skip_cleanup works the README.md and the build directory we want should be under the pwd
 - echo "Attempting to bundle playground..."
-- ls "$PWD"
-- ls "$PWD/deps/usr/build"
-- cp ./README.md ./deps/usr/build/README.md
-- cp ./LICENSE ./deps/usr/build/LICENSE
-- tar -czvf "playground-$TRAVIS_OS_NAME.tar.gz" ./deps/usr/build
+- mkdir -p playground
+- cp -r ./deps/usr/build/* ./playground/
+- cp ./README.md ./playground/README.md
+- cp ./LICENSE ./playground/LICENSE
+- tar -czvf "playground-$TRAVIS_OS_NAME.tar.gz" ./playground
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 --binary "playground-osx.tar.gz" > "SHA256SUM-osx.asc"; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum --binary "playground-linux.tar.gz" > "SHA256SUM-linux.asc"; fi
 deploy:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A package for managing julia sandboxes like python's virtualenv (with a little i
 
 
 ## Installation ##
+### With Julia ###
+The ideal way to install playground is via the registered julia package. However, this requires that you already have julia installed on you system.
 Install the julia package
 ```shell
 julia> Pkg.add("Playground")
@@ -31,6 +33,17 @@ echo "PATH=~/.playground/bin/:$PATH" >> ~/.bashrc
 This will make the playground script and all managed julia versions easily accessible.
 
 Currently, some of the dependencies in Playground.jl such as Options.jl and ArgParse.jl throw deprecation warnings. If you'd like to ignore these warnings until new versions of these packages are release just add `--depwarn=no` to the shebang in `~/.playground/bin/playground`. If you're running linux you'll need to change this line to `#!/usr/bin/julia --depwarn=no` as `env` in linux can only take 1 argument otherwise the process will stall.
+
+### Without Julia ###
+If you don't already have julia installed as of v0.0.6 (including pre-releases) and up github releases are available for download [here](https://github.com/Rory-Finnegan/Playground.jl/releases).
+Steps:
+1. Download the tar.gz file for your platform into your desired install location (ie: `~/bin`)
+1. Go to that directory (`cd ~/bin`)
+1. Extract it the build (`tar -xvzf ~/bin/playground-osx.tar.gz`)
+1. Create an alias that sets the `LD_LIBRARY_PATH` and calls the script. This should be placed in your shell rc file, so if your default shell is bash then you'd add `alias playground="LD_LIBRARY_PATH=~/bin/playground ~/bin/playground/playground"` to your `~/.bashrc` file.
+
+NOTE: This alias hack with `LD_LIBRARY_PATH` is only necessary due to an issue in the binaries created with BuildExecutable.jl. In future releases it should only be necessary for `~/bin/playground` to be on your search path (ie: in your `PATH` variable).
+
 
 ## Usage (subcommands)##
 ### install (Unix only) ###

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ A package for managing julia sandboxes like python's virtualenv (with a little i
 
 ## Installation ##
 ### With Julia ###
-The ideal way to install playground is via the registered julia package. However, this requires that you already have julia installed on you system.
-Install the julia package
+The ideal way to install playground is via the registered julia package. However, this requires that you already have julia installed on your system.
+
+Installing the julia package
 ```shell
 julia> Pkg.add("Playground")
 ```
@@ -35,14 +36,16 @@ This will make the playground script and all managed julia versions easily acces
 Currently, some of the dependencies in Playground.jl such as Options.jl and ArgParse.jl throw deprecation warnings. If you'd like to ignore these warnings until new versions of these packages are release just add `--depwarn=no` to the shebang in `~/.playground/bin/playground`. If you're running linux you'll need to change this line to `#!/usr/bin/julia --depwarn=no` as `env` in linux can only take 1 argument otherwise the process will stall.
 
 ### Without Julia ###
-If you don't already have julia installed as of v0.0.6 (including pre-releases) and up github releases are available for download [here](https://github.com/Rory-Finnegan/Playground.jl/releases).
+As of v0.0.6 and up binary releases of playground are available for download [here](https://github.com/Rory-Finnegan/Playground.jl/releases), which will allow you to run playground without having an existing julia install.
+
 Steps:
+
 1. Download the tar.gz file for your platform into your desired install location (ie: `~/bin`)
 1. Go to that directory (`cd ~/bin`)
-1. Extract it the build (`tar -xvzf ~/bin/playground-osx.tar.gz`)
+1. Extract the build (`tar -xvzf ~/bin/playground-osx.tar.gz`)
 1. Create an alias that sets the `LD_LIBRARY_PATH` and calls the script. This should be placed in your shell rc file, so if your default shell is bash then you'd add `alias playground="LD_LIBRARY_PATH=~/bin/playground ~/bin/playground/playground"` to your `~/.bashrc` file.
 
-NOTE: This alias hack with `LD_LIBRARY_PATH` is only necessary due to an issue in the binaries created with BuildExecutable.jl. In future releases it should only be necessary for `~/bin/playground` to be on your search path (ie: in your `PATH` variable).
+NOTE: This alias hack with `LD_LIBRARY_PATH` is only necessary due to an issue in the binaries created with [BuildExecutable.jl](https://github.com/dhoegh/BuildExecutable.jl). In future releases it should only be necessary for `~/bin/playground` to be on your search path (ie: in your `PATH` variable).
 
 
 ## Usage (subcommands)##

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -27,11 +27,12 @@ BUILD_PATH = joinpath(DEPS_PATH, "usr/build/")
 mkpath(BUILD_PATH)
 
 # Actually build the playground executable
+info("Trying to build playground executable in $(BUILD_PATH) ...")
 build_executable(
     "playground",
     PLAYGROUND_SCRIPT,
     BUILD_PATH,
-    "core2"; force=true
+    "generic"; force=true
 )
 
 config_file = joinpath(Playground.CONFIG_PATH, "config.yml")


### PR DESCRIPTION
Setup travis to bundle playground binaries for github releases. Resolves #19 for now.