### PR TITLE
Added Source Support for ZSH

### DIFF
--- a/src/activate.jl
+++ b/src/activate.jl
@@ -57,8 +57,11 @@ end
                     close(fstream)
                 end
             end
-
-            run(`$(ENV["SHELL"]) --rcfile $pg_rc`)
+            if contains(ENV["SHELL"],"zsh")
+                run(`$(ENV["SHELL"]) -c "source $pg_rc; $(ENV["SHELL"])"`)
+            else
+                run(`$(ENV["SHELL"]) --rcfile $pg_rc`)
+            end
         else
             run(`sh -i`)
         end


### PR DESCRIPTION
Zsh doesn't have the equivilent of bash's --rcfile, so in order for
zsh to get the exported variables, the pg_rc file has to be sourced
and then zsh called.