### PR TITLE
WIP: Remove scraping for Julia binary downloading

### DIFF
--- a/src/install.jl
+++ b/src/install.jl
@@ -10,7 +10,7 @@ function install(config::Config, version::VersionNumber; labels=[])
     init(config)
 
     # download the julia version
-    download_url = get_julia_dl_url(version, config)
+    download_url = julia_url(version)
     base_name = "julia-$(version.major).$(version.minor)_$(Dates.today())"
     tmp_dest = joinpath(config.dir.tmp, base_name)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -135,3 +135,42 @@ function get_julia_dl_url(version::VersionNumber, config::Config)
 
     return links[1]
 end
+
+
+function julia_url(version::VersionNumber, os::Symbol=OS_NAME, arch::Integer=WORD_SIZE)
+    # Cannibalized from https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/julia.rb
+
+    if os === :Linux && arch == 64
+        os_arch = "linux/x64"
+        ext = "linux-x86_64.tar.gz"
+        # nightly_ext = "linux64.tar.gz"
+    elseif os === :Linux && arch == 32
+        os_arch = "linux/x32"
+        ext = "linux-i686.tar.gz"
+        # nightly_ext = "linux32.tar.gz"
+    elseif os === :Darwin && arch == 64
+        os_arch = "osx/x64"
+        ext = "osx10.7+.dmg"
+        # nightly_ext = "osx.dmg"
+    elseif os === :Windows && arch == 64
+        os_arch = "winnt/x64"
+        ext = "win64.exe"
+    elseif os === :Windows && arch == 32
+        os_arch = "winnt/x86"
+        ext = "win32.exe"
+    else
+        error("Julia does not support $arch-bit $os")
+    end
+
+    major_minor = "$(version.major).$(version.minor)"
+    if version.patch == 0
+        url = "s3.amazonaws.com/julialang/bin/$os_arch/$major_minor/julia-$major_minor-latest-$ext"
+    else
+        url = "s3.amazonaws.com/julialang/bin/$os_arch/$major_minor/julia-$version-$ext"
+    end
+
+    # Nightly url:
+    # url = "s3.amazonaws.com/julianightlies/bin/$os_arch/julia-latest-$nightly_ext"
+
+    return "https://$url"
+end

--- a/test/install.jl
+++ b/test/install.jl
@@ -10,16 +10,8 @@ function check_url(url::AbstractString)
 end
 
 function test_url_parsing()
-    os_name = OS_NAME
-    for v in [v"0.4", v"0.5"]
-        for platform in [:Darwin, :Linux, :Windows]
-            OS_NAME = platform
-            try
-                Playground.get_julia_dl_url(v, TEST_CONFIG)
-            catch e
-                error("Failed to parse julia download url for $v on $OS_NAME")
-            end
-        end
+    for v in (v"0.4", v"0.5"), os in (:Darwin, :Linux, :Windows)
+        @test !isempty(Playground.julia_url(v, os))
     end
 end
 


### PR DESCRIPTION
Repurposed code from the Julia Travis CI script to generate a URL rather than parse a website. Should allow us to download additional version of Julia and speed up the download process. 