### PR TITLE
OS macro and readchop fix

### DIFF
--- a/src/activate.jl
+++ b/src/activate.jl
@@ -20,47 +20,43 @@ function activate(config::Config; dir::AbstractString="", name::AbstractString="
 end
 
 
-@windows_only begin
-    function run_shell(config, prompt)
-        run(`cmd /K prompt $(prompt)`)
-    end
+@windows_only function run_shell(config, prompt)
+    run(`cmd /K prompt $(prompt)`)
 end
 
 
-@unix_only begin
-    function run_shell(config, prompt)
-        ENV["PS1"] = prompt
-        if haskey(ENV, "SHELL") && contains(ENV["SHELL"], "fish")
-            run(`$(ENV["SHELL"]) -i`)
-        elseif haskey(ENV, "SHELL")
-            # Try and setup the new shell as close to the user's default shell as possible.
-            usr_rc = joinpath(homedir(), "." * basename(ENV["SHELL"]) * "rc")
-            pg_rc = joinpath(dirname(ENV["JULIA_PKGDIR"]), basename(ENV["SHELL"]) * "rc")
+@unix_only function run_shell(config, prompt)
+    ENV["PS1"] = prompt
+    if haskey(ENV, "SHELL") && contains(ENV["SHELL"], "fish")
+        run(`$(ENV["SHELL"]) -i`)
+    elseif haskey(ENV, "SHELL")
+        # Try and setup the new shell as close to the user's default shell as possible.
+        usr_rc = joinpath(homedir(), "." * basename(ENV["SHELL"]) * "rc")
+        pg_rc = joinpath(dirname(ENV["JULIA_PKGDIR"]), basename(ENV["SHELL"]) * "rc")
 
-            if !ispath(pg_rc)
-                cp(usr_rc, pg_rc)
-                fstream = open(pg_rc, "a")
-                try
-                    path = ENV["PATH"]
-                    ps1 = ENV["PS1"]
-                    pkg_dir = ENV["JULIA_PKGDIR"]
+        if !ispath(pg_rc)
+            cp(usr_rc, pg_rc)
+            fstream = open(pg_rc, "a")
+            try
+                path = ENV["PATH"]
+                ps1 = ENV["PS1"]
+                pkg_dir = ENV["JULIA_PKGDIR"]
 
-                    write(fstream, "export PATH=$path\n")
-                    write(fstream, "export PS1=\"$(prompt)\"\n")
-                    write(fstream, "export JULIA_PKGDIR=$pkg_dir\n")
+                write(fstream, "export PATH=$path\n")
+                write(fstream, "export PS1=\"$(prompt)\"\n")
+                write(fstream, "export JULIA_PKGDIR=$pkg_dir\n")
 
-                    if haskey(ENV, "HISTFILE")
-                        histfile = ENV["HISTFILE"]
-                        write(fstream, "export HISTFILE=$histfile\n")
-                    end
-                finally
-                    close(fstream)
+                if haskey(ENV, "HISTFILE")
+                    histfile = ENV["HISTFILE"]
+                    write(fstream, "export HISTFILE=$histfile\n")
                 end
+            finally
+                close(fstream)
             end
-
-            run(`$(ENV["SHELL"]) --rcfile $pg_rc`)
-        else
-            run(`sh -i`)
         end
+
+        run(`$(ENV["SHELL"]) --rcfile $pg_rc`)
+    else
+        run(`sh -i`)
     end
 end

--- a/src/clean.jl
+++ b/src/clean.jl
@@ -45,7 +45,7 @@ function Base.rm(config::Config; name::AbstractString="", dir::AbstractString=""
             error("Unknown name $name")
         end
     elseif dir == "" && name == ""
-        error("No juli-version, playground name or directory provided.")
+        error("No julia-version, playground name or directory provided.")
     end
 
     # By this point dir should be valid or the function should have already exited.

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,11 +1,5 @@
 DECLARATIVE_PACKAGES_DIR = Pkg.dir("DeclarativePackages")
-@unix_only begin
-    DEFAULT_PROMPT = "\\e[0;35m\\u@\\h:\\W (playground)> \\e[m"
-end
-@windows_only begin
-    DEFAULT_PROMPT = "playground>"
-end
-
+DEFAULT_PROMPT = @windows ? "playground>" : "\\e[0;35m\\u@\\h:\\W (playground)> \\e[m"
 JULIA_DOWNLOADS_URL = "http://julialang.org/downloads/"
 NIGHTLY = v"0.5"
 DEFAULT_CONFIG = """

--- a/src/create.jl
+++ b/src/create.jl
@@ -11,7 +11,7 @@ function create(config::Config; dir::AbstractString="", name::AbstractString="",
     if julia != ""
         mklink(joinpath(config.dir.bin, julia), pg.julia_path)
     else
-        sys_julia_path = abspath(strip(readall(`which julia`), '\n'))
+        sys_julia_path = abspath(readchomp(`which julia`))
         mklink(sys_julia_path, pg.julia_path)
     end
 


### PR DESCRIPTION
I was going through Playground.jl and I found some minor issues. Note the `@*_only` changes modified the indentation which is why it appears a lot has changed.