### PR TITLE
Remove scraping for Julia binary downloading

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,6 +1,5 @@
 DECLARATIVE_PACKAGES_DIR = Pkg.dir("DeclarativePackages")
 DEFAULT_PROMPT = @windows ? "playground>" : "\\e[0;35m\\u@\\h:\\W (playground)> \\e[m"
-JULIA_DOWNLOADS_URL = "http://julialang.org/downloads/"
 NIGHTLY = v"0.5"
 DEFAULT_CONFIG = """
 ---

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,6 +1,6 @@
 DECLARATIVE_PACKAGES_DIR = Pkg.dir("DeclarativePackages")
 DEFAULT_PROMPT = @windows ? "playground>" : "\\e[0;35m\\u@\\h:\\W (playground)> \\e[m"
-NIGHTLY = v"0.5"
+NIGHTLY = v"0.5-"
 DEFAULT_CONFIG = """
 ---
 # This is just default location to store a new playground.

--- a/src/install.jl
+++ b/src/install.jl
@@ -10,7 +10,7 @@ function install{S<:AbstractString}(config::Config, version::VersionNumber; labe
     init(config)
 
     # download the julia version
-    download_url = get_julia_dl_url(version, config)
+    download_url = julia_url(version)
     base_name = "julia-$(version.major).$(version.minor)_$(Dates.today())"
     tmp_dest = joinpath(config.dir.tmp, base_name)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -135,3 +135,42 @@ function get_julia_dl_url(version::VersionNumber, config::Config)
 
     return links[1]
 end
+
+
+function julia_url(version::VersionNumber, os::Symbol=OS_NAME, arch::Integer=WORD_SIZE)
+    # Cannibalized from https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/julia.rb
+
+    if os === :Linux && arch == 64
+        os_arch = "linux/x64"
+        ext = "linux-x86_64.tar.gz"
+        # nightly_ext = "linux64.tar.gz"
+    elseif os === :Linux && arch == 32
+        os_arch = "linux/x32"
+        ext = "linux-i686.tar.gz"
+        # nightly_ext = "linux32.tar.gz"
+    elseif os === :Darwin && arch == 64
+        os_arch = "osx/x64"
+        ext = "osx10.7+.dmg"
+        # nightly_ext = "osx.dmg"
+    elseif os === :Windows && arch == 64
+        os_arch = "winnt/x64"
+        ext = "win64.exe"
+    elseif os === :Windows && arch == 32
+        os_arch = "winnt/x86"
+        ext = "win32.exe"
+    else
+        error("Julia does not support $arch-bit $os")
+    end
+
+    major_minor = "$(version.major).$(version.minor)"
+    if version.patch == 0
+        url = "s3.amazonaws.com/julialang/bin/$os_arch/$major_minor/julia-$major_minor-latest-$ext"
+    else
+        url = "s3.amazonaws.com/julialang/bin/$os_arch/$major_minor/julia-$version-$ext"
+    end
+
+    # Nightly url:
+    # url = "s3.amazonaws.com/julianightlies/bin/$os_arch/julia-latest-$nightly_ext"
+
+    return "https://$url"
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,41 +85,61 @@ function get_playground_name(config::Config, dir::AbstractString)
     return name
 end
 
-
 function julia_url(version::VersionNumber, os::Symbol=OS_NAME, arch::Integer=WORD_SIZE)
     # Cannibalized from https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/julia.rb
 
     if os === :Linux && arch == 64
         os_arch = "linux/x64"
         ext = "linux-x86_64.tar.gz"
-        # nightly_ext = "linux64.tar.gz"
+        nightly_ext = "linux64.tar.gz"
     elseif os === :Linux && arch == 32
         os_arch = "linux/x32"
         ext = "linux-i686.tar.gz"
-        # nightly_ext = "linux32.tar.gz"
+        nightly_ext = "linux32.tar.gz"
     elseif os === :Darwin && arch == 64
         os_arch = "osx/x64"
         ext = "osx10.7+.dmg"
-        # nightly_ext = "osx.dmg"
+        nightly_ext = "osx.dmg"
     elseif os === :Windows && arch == 64
         os_arch = "winnt/x64"
         ext = "win64.exe"
+        nightly_ext = ext
     elseif os === :Windows && arch == 32
         os_arch = "winnt/x86"
         ext = "win32.exe"
+        nightly_ext = ext
     else
         error("Julia does not support $arch-bit $os")
     end
 
+    # Note: We could probably get specific revisions if we really wanted to.
+    # eg. https://status.julialang.org/download/osx10.7+ redirects to
+    # https://s3.amazonaws.com/julianightlies/bin/osx/x64/0.5/julia-0.5.0-2bb94d6f99-osx.dmg
+
     major_minor = "$(version.major).$(version.minor)"
-    if version.patch == 0
+    future_release = Base.nextpatch(NIGHTLY)  # Note: Nightly expected to be a prerelease
+    if version >= future_release
+        throw(ArgumentError("The version $version exceeds the latest known nightly build $NIGHTLY"))
+    elseif version >= NIGHTLY
+        url = "s3.amazonaws.com/julianightlies/bin/$os_arch/julia-latest-$nightly_ext"
+    elseif version.patch == 0 && version == Base.upperbound(version)
         url = "s3.amazonaws.com/julialang/bin/$os_arch/$major_minor/julia-$major_minor-latest-$ext"
     else
         url = "s3.amazonaws.com/julialang/bin/$os_arch/$major_minor/julia-$version-$ext"
     end
 
-    # Nightly url:
-    # url = "s3.amazonaws.com/julianightlies/bin/$os_arch/julia-latest-$nightly_ext"
-
     return "https://$url"
+end
+
+function julia_url(version::AbstractString, os::Symbol=OS_NAME, arch::Integer=WORD_SIZE)
+    if version == "nightly"
+        ver = NIGHTLY
+    elseif version == "release"
+        latest_release = VersionNumber(NIGHTLY.major, NIGHTLY.minor - 1, 0, (), ("",))
+        ver = latest_release
+    else
+        ver = VersionNumber(version)
+    end
+
+    return julia_url(ver, os, arch)
 end

--- a/test/install.jl
+++ b/test/install.jl
@@ -1,23 +1,6 @@
-# @doc doc"""
-#     Lets us use wget to check that all the binurls are still valid.
-# """ ->
-function check_url(url::AbstractString)
-    try
-        run(`wget -q --spider $url`)
-    catch exc
-        error("$url not reachable.")
-    end
-end
-
-function test_url_parsing()
-    for v in (v"0.4", v"0.5"), os in (:Darwin, :Linux, :Windows)
-        @test !isempty(Playground.julia_url(v, os))
-    end
-end
-
 function test_install()
     install(TEST_CONFIG, v"0.4.0"; labels=["julia-bin", "julia-stable-bin"])
-    install(TEST_CONFIG, v"0.5.0"; labels=["julia-nightly-bin"])
+    install(TEST_CONFIG, v"0.5.0-"; labels=["julia-nightly-bin"])
 end
 
 function test_dirinstall()
@@ -33,6 +16,5 @@ function test_dirinstall()
     )
 end
 
-test_url_parsing()
 test_install()
 test_dirinstall()

--- a/test/install.jl
+++ b/test/install.jl
@@ -10,16 +10,8 @@ function check_url(url::AbstractString)
 end
 
 function test_url_parsing()
-    os_name = OS_NAME
-    for v in [v"0.4", v"0.5"]
-        for platform in [:Darwin, :Linux, :Windows]
-            OS_NAME = platform
-            try
-                Playground.get_julia_dl_url(v, TEST_CONFIG)
-            catch e
-                error("Failed to parse julia download url for $v on $OS_NAME")
-            end
-        end
+    for v in (v"0.4", v"0.5"), os in (:Darwin, :Linux, :Windows)
+        @test !isempty(Playground.julia_url(v, os))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ Playground.init(TEST_CONFIG)
 # Order matters.
 tests = [
     "lint",
+    "utils",
     "list",
     "parsing",
     "install",

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,18 @@
+
+@test contains(basename(Playground.julia_url(Playground.NIGHTLY)), "julia-latest")
+@test contains(basename(Playground.julia_url(v"0.4+")), "julia-0.4-latest")
+@test contains(basename(Playground.julia_url(v"0.4")), "julia-0.4.0")
+@test_throws ArgumentError Playground.julia_url(Base.nextpatch(Playground.NIGHTLY))
+
+@test contains(basename(Playground.julia_url("nightly")), "julia-latest")
+@test ismatch(r"julia-.*-latest", basename(Playground.julia_url("release")))
+@test contains(basename(Playground.julia_url("0.4")), "julia-0.4.0")
+
+# Testing coverage
+for v in (v"0.4", v"0.5-"), os in (:Darwin, :Linux, :Windows), arch in (32, 64)
+    if os == :Darwin && arch == 32
+        @test_throws ErrorException Playground.julia_url(v, os, arch)
+    else
+        @test !isempty(Playground.julia_url(v, os, arch))
+    end
+end


### PR DESCRIPTION
Repurposed code from the Julia Travis CI script to generate a URL rather than parse a website. Should allow us to download additional version of Julia and speed up the download process. Additionally corrects some issues with how VersionNumber was being handled.