### PR TITLE
Getting playground working on 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ script:
 - julia --depwarn=no -e 'ENV["PLAYGROUND_INSTALL"] = true; Pkg.build("Playground");
   Pkg.test("Playground";  coverage=true)'
 - ~/.playground/bin/playground list
+- rm ~/.playground/bin/playground
+- julia 'ENV["PLAYGROUND_INSTALL"] = true; ENV["PLAYGROUND_BIN_EXEC"] = true; Pkg.build("Playground")'
+- ~/.playground/bin/playground list
 after_success:
 - julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 - julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,31 @@ os:
 - linux
 julia:
 - 0.4
+- 0.5
 env:
   global:
     secure: CD5Wv1UQ8oM+3tLPBxWiWS9XdMfFxwCSKbMzteaFrtSgY06DIdNON6cPr3zKARHHKiX0hsznU3vNTnOkYfXrmEPocep5YDBNccA3uWTUfP/j/Zrg2oUuTdc2ZKhUZIupqQf6FfJ8IudgrMrWd/LRBchKahNSCmvomP+4cXRTouk=
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-5
 notifications:
   email: false
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     sudo add-apt-repository ppa:staticfloat/julia-deps -y;
     sudo apt-get update -qq -y;
-    sudo apt-get install patchelf;
+    mkdir -p $HOME/bin;
+    ln -s /usr/bin/gcc-5 $HOME/bin/gcc;
+    ln -s /usr/bin/gcc-5 $HOME/bin/x86_64-linux-gnu-gcc;
+    gcc --version;
   fi
 script:
 - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 # initial clone so that we install the dependencies correctly, but this copies the pwd
-- julia -e 'Pkg.clone(pwd())'
+- julia -e 'Pkg.clone("https://github.com/dhoegh/BuildExecutable.jl"); Pkg.build("BuildExecutable"); Pkg.clone(pwd())'
 # remove the copy
 - rm -rf "$HOME/.julia/v$TRAVIS_JULIA_VERSION/Playground"
 # symlink in the pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   Pkg.test("Playground";  coverage=true)'
 - ~/.playground/bin/playground list
 - rm ~/.playground/bin/playground
-- julia 'ENV["PLAYGROUND_INSTALL"] = true; ENV["PLAYGROUND_BIN_EXEC"] = true; Pkg.build("Playground")'
+- julia -e 'ENV["PLAYGROUND_INSTALL"] = true; ENV["PLAYGROUND_BIN_EXEC"] = true; Pkg.build("Playground")'
 - ~/.playground/bin/playground list
 after_success:
 - julia -e 'cd(Pkg.dir("Playground")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ A package for managing julia sandboxes like python's virtualenv (with a little i
 The ideal way to install playground is via the registered julia package. However, this requires that you already have julia installed on your system.
 
 Installing the julia package
-```shell
+```julia
 julia> Pkg.add("Playground")
 ```
 
 NOTE: As of v0.0.6 you will need to run
-```shell
+```julia
 julia> ENV["PLAYGROUND_INSTALL"] = true
 ```
 prior to running `Pkg.add` or `Pkg.build` if you'd like the compiled playground executable to be installed into the common `~/.playground/bin/` path.
@@ -28,7 +28,7 @@ Running the playground script
 ~/.playground/bin/playground
 ```
 
-Recommended: add the playground bin directory to your path 
+Recommended: add the playground bin directory to your path
 by editing your ~/.bashrc, ~/.zshrc, ~/.tcshrc, etc.
 ```shell
 echo "PATH=~/.playground/bin/:$PATH" >> ~/.bashrc
@@ -50,6 +50,25 @@ Steps:
 
 NOTE: This alias hack with `LD_LIBRARY_PATH` is only necessary due to an issue in the binaries created with [BuildExecutable.jl](https://github.com/dhoegh/BuildExecutable.jl). In future releases it should only be necessary for `~/bin/playground` to be on your search path (ie: in your `PATH` variable).
 
+### Making Binary Executables
+
+If you'd like to build you own playground binary executables you'll have a few more steps.
+First, add `BuildExecutable`
+
+```julia
+julia> Pkg.add("BuildExecutable")
+```
+
+If you're on linux you may want to install the latest master release which will handle installing `patchelf` for you.
+
+```julia
+julia> Pkg.clone("https://github.com/dhoegh/BuildExecutable.jl")
+```
+In order to tell the Playground.jl build script to create a binary executable you'll need to run
+```julia
+julia> ENV["PLAYGROUND_BIN_EXEC"] = true
+```
+prior to calling `Pkg.build("Playground")`.
 
 ## Usage (subcommands)##
 ### install (Unix only) ###

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ ArgParse
 YAML
 BuildExecutable
 Mocking
+Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,5 @@
 julia 0.4
 ArgParse
 YAML
-BuildExecutable
 Mocking
 Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4
 ArgParse
 YAML
 BuildExecutable
+Mocking

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,7 +10,7 @@ mkpath(build_dir)
 
 build_script = "script.jl"
 
-bin_exec = haskey(ENV, "PLAYGROUND_BIN_EXEC") ? ENV["PLAYGROUND_BIN_EXEC"] : false
+bin_exec = haskey(ENV, "PLAYGROUND_BIN_EXEC") ? parse(ENV["PLAYGROUND_BIN_EXEC"]) : false
 
 if bin_exec
     # Actually build the playground executable
@@ -53,7 +53,7 @@ Playground.copy(joinpath(deps_dir, "..", "README.md"), joinpath(build_dir, "READ
 # PLAYGROUND_INSTALL env variable has been set.
 # This is just cause there isn't a `Pkg.install` or
 # `Pkg.build("Pkg", install=true)`
-install = haskey(ENV, "PLAYGROUND_INSTALL") ? ENV["PLAYGROUND_INSTALL"] : false
+install = haskey(ENV, "PLAYGROUND_INSTALL") ? parse(ENV["PLAYGROUND_INSTALL"]) : false
 
 # Store our install paths
 install_dir = Playground.config_path()

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,4 @@
-using BuildExecutable
+using Compat
 import Playground
 
 # Get our current working path
@@ -10,14 +10,24 @@ mkpath(build_dir)
 
 build_script = "script.jl"
 
-# Actually build the playground executable
-info("Trying to build playground executable in $build_dir ...")
-build_executable(
-    "playground",
-    build_script,
-    build_dir,
-    "generic"; force=true
-)
+bin_exec = haskey(ENV, "PLAYGROUND_BIN_EXEC") ? ENV["PLAYGROUND_BIN_EXEC"] : false
+
+if bin_exec
+    # Actually build the playground executable
+    info("Trying to build playground executable in $build_dir ...")
+    using BuildExecutable
+    build_executable(
+        "playground",
+        build_script,
+        build_dir,
+        "generic"; force=true
+    )
+else
+    info("Copying playground script to $build_dir")
+    PKG_PLAYGROUND_BIN = joinpath(deps_dir, "usr", "bin", "playground")
+    Playground.copy(PKG_PLAYGROUND_BIN, joinpath(build_dir, "playground"))
+    chmod(joinpath(build_dir, "playground"), filemode(PKG_PLAYGROUND_BIN))
+end
 
 config_file = joinpath(build_dir, "config.yml")
 
@@ -32,7 +42,7 @@ open(config_file, "w+") do fstream
     write(fstream, Playground.DEFAULT_CONFIG)
 end
 
-@unix_only begin
+@compat if is_unix()
     Playground.copy(joinpath(deps_dir, "usr", "bin", "INSTALL.sh"), joinpath(build_dir, "INSTALL.sh"))
 end
 
@@ -43,7 +53,7 @@ Playground.copy(joinpath(deps_dir, "..", "README.md"), joinpath(build_dir, "READ
 # PLAYGROUND_INSTALL env variable has been set.
 # This is just cause there isn't a `Pkg.install` or
 # `Pkg.build("Pkg", install=true)`
-install = haskey(ENV, "PLAYGROUND_INSTALL")
+install = haskey(ENV, "PLAYGROUND_INSTALL") ? ENV["PLAYGROUND_INSTALL"] : false
 
 # Store our install paths
 install_dir = Playground.config_path()

--- a/src/Playground.jl
+++ b/src/Playground.jl
@@ -77,7 +77,6 @@ function main(cmd_args=ARGS, config="", root="")
             name=args["name"],
             julia=args["julia-version"],
             reqs_file=args["requirements"],
-            reqs_type=args["req-type"],
         )
     elseif cmd == "activate"
         activate(

--- a/src/Playground.jl
+++ b/src/Playground.jl
@@ -4,6 +4,7 @@ module Playground
 
 using Compat
 using ArgParse
+using Mocking
 
 include("constants.jl")
 include("config.jl")

--- a/src/activate.jl
+++ b/src/activate.jl
@@ -20,47 +20,48 @@ function activate(config::Config; dir::AbstractString="", name::AbstractString="
 end
 
 
-@windows_only function run_shell(config, prompt)
-    @mock run(`cmd /K prompt $(prompt)`)
-end
+if is_windows()
+    function run_shell(config, prompt)
+        @mock run(`cmd /K prompt $(prompt)`)
+    end
+elseif is_unix()
+    function run_shell(config, prompt)
+        ENV["PS1"] = prompt
+        if haskey(ENV, "SHELL") && contains(ENV["SHELL"], "fish")
+            @mock run(`$(ENV["SHELL"]) -i`)
+        elseif haskey(ENV, "SHELL")
+            # Try and setup the new shell as close to the user's default shell as possible.
+            usr_rc = joinpath(homedir(), "." * basename(ENV["SHELL"]) * "rc")
+            pg_rc = joinpath(dirname(ENV["JULIA_PKGDIR"]), basename(ENV["SHELL"]) * "rc")
 
+            if !ispath(pg_rc)
+                cp(usr_rc, pg_rc, follow_symlinks=true)
+                fstream = open(pg_rc, "a")
+                try
+                    path = ENV["PATH"]
+                    ps1 = ENV["PS1"]
+                    pkg_dir = ENV["JULIA_PKGDIR"]
 
-@unix_only function run_shell(config, prompt)
-    ENV["PS1"] = prompt
-    if haskey(ENV, "SHELL") && contains(ENV["SHELL"], "fish")
-        @mock run(`$(ENV["SHELL"]) -i`)
-    elseif haskey(ENV, "SHELL")
-        # Try and setup the new shell as close to the user's default shell as possible.
-        usr_rc = joinpath(homedir(), "." * basename(ENV["SHELL"]) * "rc")
-        pg_rc = joinpath(dirname(ENV["JULIA_PKGDIR"]), basename(ENV["SHELL"]) * "rc")
+                    write(fstream, "export PATH=$path\n")
+                    write(fstream, "export PS1=\"$(prompt)\"\n")
+                    write(fstream, "export JULIA_PKGDIR=$pkg_dir\n")
 
-        if !ispath(pg_rc)
-            cp(usr_rc, pg_rc, follow_symlinks=true)
-            fstream = open(pg_rc, "a")
-            try
-                path = ENV["PATH"]
-                ps1 = ENV["PS1"]
-                pkg_dir = ENV["JULIA_PKGDIR"]
-
-                write(fstream, "export PATH=$path\n")
-                write(fstream, "export PS1=\"$(prompt)\"\n")
-                write(fstream, "export JULIA_PKGDIR=$pkg_dir\n")
-
-                if haskey(ENV, "HISTFILE")
-                    histfile = ENV["HISTFILE"]
-                    write(fstream, "export HISTFILE=$histfile\n")
+                    if haskey(ENV, "HISTFILE")
+                        histfile = ENV["HISTFILE"]
+                        write(fstream, "export HISTFILE=$histfile\n")
+                    end
+                finally
+                    close(fstream)
                 end
-            finally
-                close(fstream)
             end
-        end
 
-		if contains(ENV["SHELL"],"zsh")
-			@mock run(`$(ENV["SHELL"]) -c "source $pg_rc; $(ENV["SHELL"])"`)
-		else
-			@mock run(`$(ENV["SHELL"]) --rcfile $pg_rc`)
-		end
-    else
-        @mock run(`sh -i`)
+    		if contains(ENV["SHELL"],"zsh")
+    			@mock run(`$(ENV["SHELL"]) -c "source $pg_rc; $(ENV["SHELL"])"`)
+    		else
+    			@mock run(`$(ENV["SHELL"]) --rcfile $pg_rc`)
+    		end
+        else
+            @mock run(`sh -i`)
+        end
     end
 end

--- a/src/activate.jl
+++ b/src/activate.jl
@@ -21,14 +21,14 @@ end
 
 
 @windows_only function run_shell(config, prompt)
-    run(`cmd /K prompt $(prompt)`)
+    @mock run(`cmd /K prompt $(prompt)`)
 end
 
 
 @unix_only function run_shell(config, prompt)
     ENV["PS1"] = prompt
     if haskey(ENV, "SHELL") && contains(ENV["SHELL"], "fish")
-        run(`$(ENV["SHELL"]) -i`)
+        @mock run(`$(ENV["SHELL"]) -i`)
     elseif haskey(ENV, "SHELL")
         # Try and setup the new shell as close to the user's default shell as possible.
         usr_rc = joinpath(homedir(), "." * basename(ENV["SHELL"]) * "rc")
@@ -54,13 +54,13 @@ end
                 close(fstream)
             end
         end
-		
+
 		if contains(ENV["SHELL"],"zsh")
-			run(`$(ENV["SHELL"]) -c "source $pg_rc; $(ENV["SHELL"])"`)
+			@mock run(`$(ENV["SHELL"]) -c "source $pg_rc; $(ENV["SHELL"])"`)
 		else
-			run(`$(ENV["SHELL"]) --rcfile $pg_rc`)
+			@mock run(`$(ENV["SHELL"]) --rcfile $pg_rc`)
 		end
     else
-        run(`sh -i`)
+        @mock run(`sh -i`)
     end
 end

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,6 +1,6 @@
 DECLARATIVE_PACKAGES_DIR = Pkg.dir("DeclarativePackages")
 DEFAULT_PROMPT = @windows ? "playground>" : "\\e[0;35m\\u@\\h:\\W (playground)> \\e[m"
-NIGHTLY = v"0.5-"
+NIGHTLY = v"0.6-"
 DEFAULT_CONFIG = """
 ---
 # This is just default location to store a new playground.

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,5 +1,5 @@
 DECLARATIVE_PACKAGES_DIR = Pkg.dir("DeclarativePackages")
-DEFAULT_PROMPT = @windows ? "playground>" : "\\e[0;35m\\u@\\h:\\W (playground)> \\e[m"
+DEFAULT_PROMPT = is_windows() ? "playground>" : "\\e[0;35m\\u@\\h:\\W (playground)> \\e[m"
 NIGHTLY = v"0.6-"
 DEFAULT_CONFIG = """
 ---

--- a/src/create.jl
+++ b/src/create.jl
@@ -64,7 +64,7 @@ function create(config::Config; dir::AbstractString="", name::AbstractString="",
                         try
                             rm(d, recursive=true)
                         catch
-                            @unix_only begin
+                            @compat if is_unix()
                                 run(`chmod -R 755 $d`)
                                 run(`rm -rf $d`)
                             end

--- a/src/create.jl
+++ b/src/create.jl
@@ -1,5 +1,5 @@
 function create(config::Config; dir::AbstractString="", name::AbstractString="",
-    julia::AbstractString="", reqs_file::AbstractString="", reqs_type::Symbol=:REQUIRE)
+    julia::AbstractString="", reqs_file::AbstractString="")
 
     init(config)
 
@@ -22,71 +22,15 @@ function create(config::Config; dir::AbstractString="", name::AbstractString="",
     ENV["JULIA_PKGDIR"] = pg.pkg_path
 
     if reqs_file != "" && ispath(reqs_file)
-        if basename(reqs_file) == "DECLARE" || reqs_type == :DECLARE
-            if ispath(DECLARATIVE_PACKAGES_DIR)
-                ENV["DECLARE"] = reqs_file
-                ENV["JULIA_PKGDIR"] = joinpath(pg.pkg_path, ".declare_packages")
-                mkpath(ENV["JULIA_PKGDIR"])
-                copy(reqs_file, joinpath(ENV["JULIA_PKGDIR"], "DECLARE"))
-
-                old_folders = readdir(pg.pkg_path)
-                info("Installing packages from DECLARE file $reqs_file...")
-                passed = false
-                try
-                    run(`$(pg.julia_path) $(DECLARATIVE_PACKAGES_DIR)/src/installpackages.jl`)
-                    passed = true
-                catch
-                    passed = false
-                    warn("Failed to install from DECLARE file. Perhaps there is something wrong with your DECLARE file or you need to update DeclarativePackages.jl")
-                end
-
-                if passed
-                    # Despite a declarative packages JULIA_PKGDIR being provided
-                    # DeclarativePackages will just create a temporary folder
-                    # in the parent directory. So we compare the pg.pkg_path before
-                    # and after running installpackages.jl. Once, we find the generated folder
-                    # that isn't just symlinks we copy the version folder over.
-                    new_folders = readdir(pg.pkg_path)
-                    to_delete = []
-                    for f in new_folders
-                        if !(f in old_folders)
-                            declared_folder = joinpath(pg.pkg_path, f)
-                            push!(to_delete, declared_folder)
-                            if !islink(declared_folder) && isdir(declared_folder)
-                                for v in readdir(declared_folder)
-                                    vfolder = joinpath(declared_folder, v)
-                                    copy(vfolder, joinpath(pg.pkg_path, v))
-                                end
-                            end
-                        end
-                    end
-                    for d in to_delete
-                        try
-                            rm(d, recursive=true)
-                        catch
-                            @compat if is_unix()
-                                run(`chmod -R 755 $d`)
-                                run(`rm -rf $d`)
-                            end
-                        end
-                    end
-                end
-            else
-                warn("DeclarativePackages isn't installed")
+        info("Installing packages from REQUIRE file $reqs_file...")
+        run(`$(pg.julia_path) -e Pkg.init()`)
+        for v in readdir(pg.pkg_path)
+            copy(reqs_file, joinpath(pg.pkg_path, v, "REQUIRE"))
+            try
+                run(`$(pg.julia_path) -e Pkg.resolve()`)
+            catch
+                warn("Failed to resolve requirements. Perhaps there is something wrong with your REQUIRE file.")
             end
-        elseif basename(reqs_file) == "REQUIRE" || reqs_type == :REQUIRE
-            info("Installing packages from REQUIRE file $reqs_file...")
-            run(`$(pg.julia_path) -e Pkg.init()`)
-            for v in readdir(pg.pkg_path)
-                copy(reqs_file, joinpath(pg.pkg_path, v, "REQUIRE"))
-                try
-                    run(`$(pg.julia_path) -e Pkg.resolve()`)
-                catch
-                    warn("Failed to resolve requirements. Perhaps there is something wrong with your REQUIRE file.")
-                end
-            end
-        else
-            error("Unknown requirements file type $reqs_type for file $reqs_file")
         end
     else
         run(`$(pg.julia_path) -e Pkg.init()`)

--- a/src/install.jl
+++ b/src/install.jl
@@ -193,4 +193,3 @@ end
     # not sure what to do here yet.
     error("installing Julia EXEs on Windows not implemented yet.")
 end
-

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -53,10 +53,6 @@ function argparse(cmd_args=ARGS)
         "--julia-version", "-j"
             help = "The version(s) of julia available to use. If multiple versions are provided the first entry will be the one used by `julia`. By default the user/system level version is used."
             default = ""
-        "--req-type", "-t"
-            help = "If --requirments isn't being passed a path ending in REQUIRE or DECLARE file, please specify which type is it \"REQUIRE\" or \"DECLARE\""
-            arg_type = Symbol
-            default = :REQUIRE
     end
 
     @add_arg_table parse_settings["activate"] begin

--- a/test/DECLARE
+++ b/test/DECLARE
@@ -1,9 +1,0 @@
-BinDeps 0.3.15
-Compat 0.7.0
-HttpCommon 0.2.3
-JSON 0.4.5
-SHA 4eeff02a744c56bb2bb6b5a421b17fd4b98ee264
-URIParser 0.1.0
-https://github.com/rened/HDF5.jl.git 0.4.5
-https://github.com/JuliaLang/METADATA.jl.git 6c686d294bea0ca81639c0183f69f81739133da2
-@osx Homebrew 0.1.16

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-DeclarativePackages

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,1 @@
-Lint 0.1 0.2.0
 DeclarativePackages
-Mocking 0.0.2 0.1.0

--- a/test/activate.jl
+++ b/test/activate.jl
@@ -4,6 +4,5 @@ patch = @patch run(cmd::Base.AbstractCmd, args...) = println(cmd)
 Mocking.apply(patch) do
     activate(TEST_CONFIG; dir=joinpath(TEST_TMP_DIR, "test-playground"))
     activate(TEST_CONFIG; name="myproject")
-    activate(TEST_CONFIG; name="otherproject")
     activate(TEST_CONFIG)
 end

--- a/test/activate.jl
+++ b/test/activate.jl
@@ -1,10 +1,9 @@
 
-mock_run(cmd::Cmd) = cmd
+patch = @patch run(cmd::Base.AbstractCmd, args...) = println(cmd)
 
-Mocking.override(run, mock_run) do
+Mocking.apply(patch) do
     activate(TEST_CONFIG; dir=joinpath(TEST_TMP_DIR, "test-playground"))
     activate(TEST_CONFIG; name="myproject")
     activate(TEST_CONFIG; name="otherproject")
     activate(TEST_CONFIG)
 end
-

--- a/test/clean.jl
+++ b/test/clean.jl
@@ -12,9 +12,6 @@ end
 
 
 function test_rm()
-    rm(TEST_CONFIG, name="otherproject")
-    @test !ispath(joinpath(TEST_CONFIG.dir.store, "otherproject"))
-
     rm(TEST_CONFIG, dir=joinpath(TEST_DIR, ".playground"))
     @test !ispath(joinpath(TEST_DIR, ".playground"))
 

--- a/test/create.jl
+++ b/test/create.jl
@@ -12,17 +12,6 @@ function test_create()
     @test ispath(joinpath(TEST_CONFIG.dir.store, "myproject"))
     @test islink(joinpath(TEST_CONFIG.dir.store, "myproject"))
 
-    create(
-        TEST_CONFIG;
-        name="otherproject",
-        reqs_file=joinpath(TEST_DIR, "DECLARE"),
-        reqs_type=:DECLARE,
-        julia="julia-nightly-dir"
-    )
-
-    @test ispath(joinpath(TEST_CONFIG.dir.store, "otherproject"))
-    @test isdir(joinpath(TEST_CONFIG.dir.store, "otherproject"))
-
     create(TEST_CONFIG)
     @test ispath(joinpath(TEST_DIR, ".playground"))
     @test isdir(joinpath(TEST_DIR, ".playground"))

--- a/test/install.jl
+++ b/test/install.jl
@@ -1,6 +1,7 @@
 function test_install()
-    install(TEST_CONFIG, v"0.4.0"; labels=["julia-bin", "julia-stable-bin"])
-    install(TEST_CONFIG, v"0.5.0-"; labels=["julia-nightly-bin"])
+    install(TEST_CONFIG, v"0.4.0"; labels=["julia-bin", "julia-old-bin"])
+    install(TEST_CONFIG, v"0.5.0"; labels=["julia-bin", "julia-stable-bin"])
+    install(TEST_CONFIG, v"0.6.0-"; labels=["julia-nightly-bin"])
 end
 
 function test_dirinstall()

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -32,7 +32,6 @@ function test_argparse()
             "requirements" => "",
             "name" => "",
             "julia-version" => "",
-            "req-type" => :REQUIRE,
         )
     )
 
@@ -42,18 +41,7 @@ function test_argparse()
             "--name", "myplayground",
             "--julia-version", "julia-0.3",
             "--requirements", "/path/to/requirements",
-            "--req-type", "DECLARE"
         ]
-    )
-    @test create_args2 == Dict(
-        "%COMMAND%" => "create",
-        "create" => Dict(
-            "dir" => "/path/to/playground",
-            "requirements" => "/path/to/requirements",
-            "name" => "myplayground",
-            "julia-version" => "julia-0.3",
-            "req-type" => :DECLARE,
-        )
     )
 
     activate_args1 = argparse(["activate"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Base.Test
-using Lint
+# using Lint
 using Mocking
+Mocking.enable()
 
 include("../src/Playground.jl")
 using Playground
@@ -19,7 +20,7 @@ Playground.init(TEST_CONFIG)
 
 # Order matters.
 tests = [
-    "lint",
+    # "lint",
     "utils",
     "list",
     "parsing",


### PR DESCRIPTION
* Updates to get 0.5 working
* Fixing deprecation warnings
* Dropping Lint.jl and DeclarativePackages.jl
* Changed default `Pkg.build` behaviour to use a script rather than trying to build an binary executable.